### PR TITLE
Fixed Makefile and created user_conf template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-fPIC -lc -shared -I/usr/lib/jvm/java-1.6.0/include/ -I/usr/lib/jvm/java-1.6.0/include/linux/
+CFLAGS=-fPIC -lc -shared -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
 OUTPUT=libThreads.so
 
 SOURCES_DIR=src/main/native

--- a/src/main/resources/RENAMEMEuser_conf
+++ b/src/main/resources/RENAMEMEuser_conf
@@ -1,0 +1,1 @@
+{"name": "", "password": ""}


### PR DESCRIPTION
Makefile will not be fixed to a java version using JAVA_HOME environment variable to get the C headers to compile the native code. Also, create src/main/resources/RENAMEMEuser_conf file to be renamed and changed its content, so the tests can run fine if a valid user is specified and cgroups is installed and started. Probably these and other informations (such as the Cgroups installation/check if it is working/etc) needs to be added into the README.md
