### PR TITLE
Modify Makefile to use the version defined in $JAVA_HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+# Makefile for jcgroup
+
+ifndef JAVA_HOME
+	JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
+endif
 CC=gcc
-CFLAGS=-fPIC -lc -shared -I/usr/lib/jvm/java-1.6.0/include/ -I/usr/lib/jvm/java-1.6.0/include/linux/
+CFLAGS=-fPIC -lc -shared -I${JAVA_HOME}/include/ -I${JAVA_HOME}/include/linux/
 OUTPUT=libThreads.so
 
 SOURCES_DIR=src/main/native

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jcgroup is a cgroup wrapper on JVM. You could use this library to limit the CPU 
 
 ## Example
 
->This code snippet create two threads and set different cpu shares of them. One is 512 while another is 2048.
+> This code snippet create two threads and set different cpu shares of them. One is 512 while another is 2048.
 
 ![jcgroup_example_cpu][1]
 
@@ -104,13 +104,20 @@ public class ExampleTest {
 }
 ```
 
+The wrapper requires a configuration file that defines the user and the password used to create the tasks. That user must be able to run `sudo`. You must add a `user_conf` file to the classpath, e.g. in the `/src/main/resources` or the `/src/test/resources` project folder, using the following format:
+
+```
+{
+	"name" : "james",
+	"password" : "bond"  
+}
+``` 
 
 
 ## Requirements
 
 * Linux version (>= 2.6.18)
-* cgroups management tools. In Ubuntu or Debian, you may install the tools using:
-``sudo apt-get install cgroup-bin``     
+* cgroups management tools. In Ubuntu or Debian, you may install the tools using: ``sudo apt-get install cgroup-bin``     
 
   [1]: https://raw.github.com/haosdent/jcgroup/master/img/jcgroup_example_cpu.jpg
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#jcgroup
+# jcgroup
 
 [![Build Status](https://travis-ci.org/haosdent/jcgroup.png?branch=master)](https://travis-ci.org/haosdent/jcgroup) [![Coverage Status](https://coveralls.io/repos/haosdent/jcgroup/badge.png?branch=master)](https://coveralls.io/r/haosdent/jcgroup?branch=master)
 
@@ -16,6 +16,7 @@ jcgroup is a cgroup wrapper on JVM. You could use this library to limit the CPU 
 ☑ memory<br/>
 ☑ net_cls<br/>
 ☑ net_prio<br/>
+
 
 ## Example
 
@@ -108,7 +109,8 @@ public class ExampleTest {
 ## Requirements
 
 * Linux version (>= 2.6.18)
-
+* cgroups management tools. In Ubuntu or Debian, you may install the tools using:
+``sudo apt-get install cgroup-bin``     
 
   [1]: https://raw.github.com/haosdent/jcgroup/master/img/jcgroup_example_cpu.jpg
 

--- a/src/main/java/me/haosdent/cgroup/manage/Admin.java
+++ b/src/main/java/me/haosdent/cgroup/manage/Admin.java
@@ -49,7 +49,6 @@ public class Admin {
     this.password = password;
     this.subsystems = subsystems;
     this.shell = new Shell(this);
-    shell.mount(name, subsystems);
     this.rootGroup = new Group(this, PATH_ROOT, subsystems, true);
   }
 
@@ -58,7 +57,6 @@ public class Admin {
     for (Object group : groups) {
       ((Group) group).delete();
     }
-    shell.umount(name);
   }
 
   public Shell getShell() {

--- a/src/main/java/me/haosdent/cgroup/util/Constants.java
+++ b/src/main/java/me/haosdent/cgroup/util/Constants.java
@@ -6,8 +6,6 @@ public class Constants {
 
   public static final String SHELL_MKDIR = "mkdir -p %s";
   public static final String SHELL_RMDIR = "rm -rf %s";
-  public static final String SHELL_MOUNT = "mount -t cgroup -o%s %s %s";
-  public static final String SHELL_UMOUNT = "umount %s";
 
   public static final String SHELL_CG_CLEAR = "cgclear";
   public static final String SHELL_CG_CREATE = "cgcreate -g %s:%s";


### PR DESCRIPTION
fixes #10 - Uses the JAVA_HOME environment variable to detect the location of the `include` and `include/linux` folders.